### PR TITLE
added Out Of Stock option to hide cookies that are no longer available

### DIFF
--- a/CookieOrders/Models/Cookie.cs
+++ b/CookieOrders/Models/Cookie.cs
@@ -13,5 +13,6 @@ namespace CookieOrders.Models
         public string ImagePath { get; set; }
         public decimal CostPerBox { get; set; }
         public string Description { get; set; }
+        public bool OutOfStock { get; set; }
     }
 }

--- a/CookieOrders/Models/CookieViewModel.cs
+++ b/CookieOrders/Models/CookieViewModel.cs
@@ -16,14 +16,17 @@ namespace CookieOrders.Models
             Cookies = new List<CookieDTO>();
             foreach (Cookie cookie in cookieList)
             {
-                Cookies.Add(new CookieDTO()
+                if (cookie.OutOfStock == false)
                 {
-                    CookieId = cookie.CookieId,
-                    CookieType = cookie.CookieType,
-                    ImagePath = cookie.ImagePath,
-                    Name = cookie.Name,
-                    Description = cookie.Description
-                });
+                    Cookies.Add(new CookieDTO()
+                    {
+                        CookieId = cookie.CookieId,
+                        CookieType = cookie.CookieType,
+                        ImagePath = cookie.ImagePath,
+                        Name = cookie.Name,
+                        Description = cookie.Description
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
Fix to allow admin to set a cookie type to Out Of Stock which doesn't allow the customer to order that cookie type.

Closes #43 